### PR TITLE
Fix queue length reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>jenkins-statsd</artifactId>
-  <version>0.2</version>
+  <version>0.3</version>
   <packaging>hpi</packaging>
 
   <developers>


### PR DESCRIPTION
Summary: Use a list instead of a map so we can count multiple jobs with the
same name waiting in the queue.

Test plan: Tested the code in Jenkins web console.