### PR TITLE
Don't include virtual worker count in busy workers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>jenkins-statsd</artifactId>
-  <version>0.4</version>
+  <version>0.5</version>
   <packaging>hpi</packaging>
 
   <developers>

--- a/src/main/java/org/jenkinsci/plugins/statsd/StatsdPeriodicWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/statsd/StatsdPeriodicWorker.java
@@ -7,6 +7,7 @@ import hudson.Extension;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,16 @@ import static org.jenkinsci.plugins.statsd.StatsdUtils.sanitizeKey;
 public final class StatsdPeriodicWorker extends PeriodicWork {
 
     private static final Logger LOGGER = Logger.getLogger(StatsdPeriodicWorker.class.getName());
+
+    enum ExecutorState {
+        BUSY,
+        IDLE,
+    };
+
+    enum ExecutorType {
+        VIRTUAL,
+        WORKER,
+    };
 
     @Override
     public long getRecurrencePeriod() {
@@ -45,24 +56,52 @@ public final class StatsdPeriodicWorker extends PeriodicWork {
 
         int buildCount = Hudson.getInstance().getView("All").getBuilds().byTimestamp(now - config.getBuildActivitySeconds() * 1000, now).size();
 
-        int totalExecutors = 0;
-        int busyExecutors = 0;
-
-        for(Computer computer : Hudson.getInstance().getComputers()) {
-            for( Executor e : computer.getExecutors() ) {
-                totalExecutors++;
-                if( e.isBusy() ) {
-                    busyExecutors++;
-                }
+        EnumMap<ExecutorType, EnumMap<ExecutorState, Integer>> executors =
+            new EnumMap<ExecutorType, EnumMap<ExecutorState, Integer>>(ExecutorType.class);
+        for( ExecutorType executorType : ExecutorType.values() ) {
+            executors.put(executorType, new EnumMap<ExecutorState, Integer>(ExecutorState.class));
+            for( ExecutorState executorState : ExecutorState.values() ) {
+                executors.get(executorType).put(executorState, 0);
             }
         }
-        LOGGER.log(Level.INFO, "Total executors: {0} Busy Executors {1} Completed Builds {2} Queue Depth {3}",
-                new Object[]{totalExecutors, busyExecutors, buildCount, queueDepth});
 
-        sendMetrics(queueItems, queueDepth, buildCount, totalExecutors, busyExecutors);
+        for( Computer computer : Hudson.getInstance().getComputers() ) {
+            ExecutorType executorType = ExecutorType.WORKER;
+            if (computer.getDisplayName().equals("master")) {
+                executorType = ExecutorType.VIRTUAL;
+            }
+            for( Executor e : computer.getExecutors() ) {
+                ExecutorState executorState =
+                    e.isBusy() ? ExecutorState.BUSY : ExecutorState.IDLE;
+                Integer count = executors.get(executorType).get(executorState);
+                executors.get(executorType).put(executorState, count + 1);
+            }
+        }
+        LOGGER.log(
+            Level.INFO,
+            "Total executors: {0} Busy Executors {1} Virtual executors {2} " +
+            "Busy virtual executors {3} Completed Builds {4} Queue Depth {5}",
+             new Object[]{
+                 executors.get(ExecutorType.WORKER).get(ExecutorState.IDLE) +
+                 executors.get(ExecutorType.WORKER).get(ExecutorState.BUSY),
+                 executors.get(ExecutorType.WORKER).get(ExecutorState.BUSY),
+                 executors.get(ExecutorType.VIRTUAL).get(ExecutorState.IDLE) +
+                 executors.get(ExecutorType.VIRTUAL).get(ExecutorState.BUSY),
+                 executors.get(ExecutorType.VIRTUAL).get(ExecutorState.BUSY),
+                 buildCount,
+                 queueDepth,
+            }
+        );
+
+        sendMetrics(queueItems, queueDepth, buildCount, executors);
     }
 
-    private void sendMetrics(Map<String, List<Long>> queueItems, long queueDepth, int buildCount, int totalExecutors, int busyExecutors) {
+    private void sendMetrics(
+        Map<String, List<Long>> queueItems,
+        long queueDepth,
+        int buildCount,
+        EnumMap<ExecutorType, EnumMap<ExecutorState, Integer>> executors
+    ) {
 
         StatsdConfig config = StatsdConfig.get();
 
@@ -80,9 +119,17 @@ public final class StatsdPeriodicWorker extends PeriodicWork {
         }
 
         try {
+            EnumMap<ExecutorState, Integer> worker = executors.get(ExecutorType.WORKER);
+            EnumMap<ExecutorState, Integer> virtual = executors.get(ExecutorType.VIRTUAL);
             StatsdClient statsd = new StatsdClient(host, port);
-            statsd.gauge(prefix + "executors.busy", busyExecutors);
-            statsd.gauge(prefix + "executors.total", totalExecutors);
+            statsd.gauge(prefix + "executors.busy", worker.get(ExecutorState.BUSY));
+            statsd.gauge(prefix + "executors.idle", worker.get(ExecutorState.IDLE));
+            statsd.gauge(prefix + "executors.total",
+                         worker.get(ExecutorState.BUSY) + worker.get(ExecutorState.IDLE));
+            statsd.gauge(prefix + "executors.master.busy", virtual.get(ExecutorState.BUSY));
+            statsd.gauge(prefix + "executors.master.idle", virtual.get(ExecutorState.IDLE));
+            statsd.gauge(prefix + "executors.master.total",
+                         virtual.get(ExecutorState.BUSY) + virtual.get(ExecutorState.IDLE));
             statsd.gauge(prefix + "builds.started", buildCount);
             statsd.gauge(prefix + "builds.queue.length", queueDepth);
             for( Map.Entry<String, List<Long>> entry : queueItems.entrySet()) {


### PR DESCRIPTION
Summary: We're mixing up counts for worker machines and virtual master workers
which messes up the busy machine graphs.

Test plan: Installed in a local Jenkins instance, will also test in staging.
From Jenkins log:
```
Total executors: 1 Busy Executors 0 Virtual executors 100 Busy virtual executors 0 Completed Builds 0 Queue Depth 0
```