### PR TITLE
Don't count offline executors as idle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>jenkins-statsd</artifactId>
-  <version>0.5</version>
+  <version>0.6</version>
   <packaging>hpi</packaging>
 
   <developers>


### PR DESCRIPTION
Summary: We're wrongly classifying offline executors as idle.

Test plan: Installed and used the plugin.