### PR TITLE
Add a draining state for executors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>jenkins-statsd</artifactId>
-  <version>0.6</version>
+  <version>0.7</version>
   <packaging>hpi</packaging>
 
   <developers>


### PR DESCRIPTION
Summary: Executors marked as shutdown are draining.

Test plan: Installed and used the plugin.